### PR TITLE
Add useSubscription hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,20 @@ Don't forget to replace DISTRO with your ROS distribution - *noetic*, *melodic*,
 
 1. RosConnection - COMPONENT: setup the connection. Wraps all other ROS components except ImageViewer
 2. Subscriber - COMPONENT: setup and execute a subscriber. Components wrapped by this subscriber will have access to incoming messages through the *useMsg* hooks.
-3. useMsg - HOOK: Use this hook in a component wrapped by a *Subscriber* to get access to incoming messages.
-4. Publisher - COMPONENT: setup and execute a publisher
-5. ImageViewer - COMPONENT: view streaming from web_video_server http streaming server.
-6. ServiceCaller - COMPONENT: call service
-7. ServiceServer - COMPONENT: setup a service server
-8. Param - COMPONENT: get, set, or delete a ros parameters from the server parameters
-9. useParam - HOOK: use in a component wrapped by a Param component to get the parameter value.
-10. TopicListProvider - COMPONENT
-11. useTopicList - HOOK
-12. ParamListProvider - COMPONENT
-13. useParamList - HOOK
-14. ServiceListProvider - COMPONENT
-15. useServiceList - HOOK
+3. useSubscription - HOOK: All-In-One version of subscriber as a react hook, good to be used inside any component.
+4. useMsg - HOOK: Use this hook in a component wrapped by a *Subscriber* to get access to incoming messages.
+5. Publisher - COMPONENT: setup and execute a publisher
+6. ImageViewer - COMPONENT: view streaming from web_video_server http streaming server.
+7. ServiceCaller - COMPONENT: call service
+8. ServiceServer - COMPONENT: setup a service server
+9. Param - COMPONENT: get, set, or delete a ros parameters from the server parameters
+10. useParam - HOOK: use in a component wrapped by a Param component to get the parameter value.
+11. TopicListProvider - COMPONENT
+12. useTopicList - HOOK
+13. ParamListProvider - COMPONENT
+14. useParamList - HOOK
+15. ServiceListProvider - COMPONENT
+16. useServiceList - HOOK
 
 ### **Example**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@testing-library/react": "^13.3.0",
         "@types/jest": "^28.1.7",
         "@types/react": "^18.0.17",
-        "@types/roslib": "^1.1.10",
+        "@types/roslib": "^1.3.0",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^28.1.3",
         "react": "^18.2.0",
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@types/roslib": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@types/roslib/-/roslib-1.1.10.tgz",
-      "integrity": "sha512-e4GB+i8nDagl6PX/6TpzDBjfbanAXlOD8AmOEJNzgs2u+WHVkXlR9PKlG4EothVAqjR2yahCple/nXwsGd9TSQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/roslib/-/roslib-1.3.1.tgz",
+      "integrity": "sha512-k6kZDAYS75P1s9phgdlHcg4DmP9blusZGftS2YQWR6uZ1zSBNgmt0xv5vbEOQ+yqemucrvEYKIaUxfMVeIZ6Vg==",
       "dev": true,
       "dependencies": {
         "eventemitter2": "^6.4.0"
@@ -10253,9 +10253,9 @@
       }
     },
     "@types/roslib": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@types/roslib/-/roslib-1.1.10.tgz",
-      "integrity": "sha512-e4GB+i8nDagl6PX/6TpzDBjfbanAXlOD8AmOEJNzgs2u+WHVkXlR9PKlG4EothVAqjR2yahCple/nXwsGd9TSQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/roslib/-/roslib-1.3.1.tgz",
+      "integrity": "sha512-k6kZDAYS75P1s9phgdlHcg4DmP9blusZGftS2YQWR6uZ1zSBNgmt0xv5vbEOQ+yqemucrvEYKIaUxfMVeIZ6Vg==",
       "dev": true,
       "requires": {
         "eventemitter2": "^6.4.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@testing-library/react": "^13.3.0",
     "@types/jest": "^28.1.7",
     "@types/react": "^18.0.17",
-    "@types/roslib": "^1.1.10",
+    "@types/roslib": "^1.3.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
     "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "types": "dist/esm/index.d.ts",
   "scripts": {

--- a/src/components/Param/Param.tsx
+++ b/src/components/Param/Param.tsx
@@ -14,7 +14,7 @@ export const Param = (props: ParamProps) => {
     const [paramValue, setParamValue] = useState(null);
 
     useEffect(() => {
-        if (!(props.setValue == null)) {
+        if (!(props.setValue == null) && !(props.setCallback == null)) {
             param.set(props.setValue, props.setCallback)
         }
     }, [props.setValue]);

--- a/src/components/Subscriber/Subscriber.tsx
+++ b/src/components/Subscriber/Subscriber.tsx
@@ -43,7 +43,7 @@ export const Subscriber = (props: SubscriberComponentProps) => {
     );
 }
 
-type DefaultMessageType = Message;
+export type DefaultMessageType = Message;
 
 export interface SubscriberProps<TMessage = DefaultMessageType> {
     topic: string;

--- a/src/components/Subscriber/index.ts
+++ b/src/components/Subscriber/index.ts
@@ -1,1 +1,2 @@
 export {Subscriber, useMsg, subscribe, unsubscribe, TopicSettings, getTopic} from "./Subscriber";
+export {useSubscription, UseSubscriptionProps} from './useSubscription';

--- a/src/components/Subscriber/useSubscription.tsx
+++ b/src/components/Subscriber/useSubscription.tsx
@@ -1,0 +1,97 @@
+import { useRos } from '../RosConnection';
+import { useEffect, useRef, useState } from 'react';
+import {
+    DefaultMessageType,
+    subscribe,
+    SubscriberProps,
+    unsubscribe,
+} from './Subscriber';
+
+// TODO allow for sharing topics instead of creating a new one every time
+
+export type UseSubscriptionProps<TMessage = DefaultMessageType> =
+    SubscriberProps<TMessage> & {
+        /**
+         * Function to determine if messages are the same to cut down on renders. Do not set if you want every message.
+         * @param o1 The existing message
+         * @param o2 The new incoming message
+         * @return Standard comparison result, `true` or `0` if equal, `false` or non-zero otherwise.
+         */
+        compareFunc?: (
+            o1: TMessage | null | undefined,
+            o2: TMessage | null | undefined,
+        ) => boolean | number;
+    };
+
+export function useSubscription<TMessage = DefaultMessageType>(
+    props: UseSubscriptionProps<TMessage>,
+): TMessage | null {
+    const ros = useRos();
+
+    const {
+        topic,
+        messageType,
+        throttleRate,
+        latch,
+        queueLength,
+        queueSize,
+        customCallback,
+        compareFunc,
+    } = props;
+
+    const [message, setMessage] = useState<TMessage | null>(
+        props.messageInitialValue ?? null,
+    );
+    const messageRef = useRef(message);
+
+    const updateMessage = (msg: TMessage) => {
+        setMessage(msg);
+        messageRef.current = msg;
+    };
+
+    useEffect(() => {
+        const messageCallback = (newMsg: TMessage) => {
+            if (compareFunc) {
+                const compareRes = compareFunc(messageRef.current, newMsg);
+                // The values are the same, return.
+                if (compareRes === true || compareRes === 0) {
+                    return;
+                }
+            }
+
+            if (customCallback) {
+                customCallback(newMsg);
+            }
+
+            updateMessage(newMsg);
+        };
+
+        const subscription = subscribe(
+            ros,
+            {
+                topic,
+                messageType,
+                throttleRate,
+                latch,
+                queueLength,
+                queueSize,
+            },
+            messageCallback,
+        );
+
+        return () => {
+            unsubscribe(subscription, messageCallback);
+        };
+    }, [
+        topic,
+        messageType,
+        throttleRate,
+        latch,
+        queueLength,
+        queueSize,
+        customCallback,
+        compareFunc,
+    ]);
+
+    return message;
+}

--- a/src/components/Subscriber/useSubscription.tsx
+++ b/src/components/Subscriber/useSubscription.tsx
@@ -44,12 +44,12 @@ export function useSubscription<TMessage = DefaultMessageType>(
     );
     const messageRef = useRef(message);
 
-    const updateMessage = (msg: TMessage) => {
-        setMessage(msg);
-        messageRef.current = msg;
-    };
-
     useEffect(() => {
+        const updateMessage = (msg: TMessage) => {
+            setMessage(msg);
+            messageRef.current = msg;
+        };
+
         const messageCallback = (newMsg: TMessage) => {
             if (compareFunc) {
                 const compareRes = compareFunc(messageRef.current, newMsg);
@@ -83,6 +83,7 @@ export function useSubscription<TMessage = DefaultMessageType>(
             unsubscribe(subscription, messageCallback);
         };
     }, [
+        ros,
         topic,
         messageType,
         throttleRate,


### PR DESCRIPTION
This PR adds generic types to the `SubscriberProps` interface to take advantage of type checking in callbacks, topics, etc. as well as a hook-based version of Subscriber.
For some components, I wanted to have multiple subscriptions to different topics but didn't want to have to deal with a lot of context management, so I made a hook based on the base component.
This implementation also adds a prop to compare the old/new versions of the message to cut down on re renders. This could be lodash deep compare, or just `Object.is`

Use Case:
```ts
type TestTopicManagerProps = {};

const testPublisherProps: UseSubscriptionProps<std_msgs.String> = {
  topic: '/rosbridgetest/publisher',
  messageType: 'std_msgs/String',
  compareFunc: Object.is,
  customCallback: msg => {
    console.log('Got ROS Message: ', msg);
  },
};

export const TestTopicManager: React.FC<TestTopicManagerProps> = () => {
  const testMessage = useSubscription<std_msgs.String>(testPublisherProps);

  return <div>Last Data: {testMessage?.data}</div>;
};
```

This PR also fixes #1, sourcemaps referenced the src directory, which never got packed in the release bundle.