### PR TITLE
Add useServiceCall for hook-based option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,16 @@ Don't forget to replace DISTRO with your ROS distribution - *noetic*, *melodic*,
 5. Publisher - COMPONENT: setup and execute a publisher
 6. ImageViewer - COMPONENT: view streaming from web_video_server http streaming server.
 7. ServiceCaller - COMPONENT: call service
-8. ServiceServer - COMPONENT: setup a service server
-9. Param - COMPONENT: get, set, or delete a ros parameters from the server parameters
-10. useParam - HOOK: use in a component wrapped by a Param component to get the parameter value.
-11. TopicListProvider - COMPONENT
-12. useTopicList - HOOK
-13. ParamListProvider - COMPONENT
-14. useParamList - HOOK
-15. ServiceListProvider - COMPONENT
-16. useServiceList - HOOK
+8. useServiceCall - HOOK: Provides callback and promise-based functions for service calls as a hook.
+9. ServiceServer - COMPONENT: setup a service server
+10. Param - COMPONENT: get, set, or delete a ros parameters from the server parameters
+11. useParam - HOOK: use in a component wrapped by a Param component to get the parameter value.
+12. TopicListProvider - COMPONENT
+13. useTopicList - HOOK
+14. ParamListProvider - COMPONENT
+15. useParamList - HOOK
+16. ServiceListProvider - COMPONENT
+17. useServiceList - HOOK
 
 ### **Example**
 

--- a/src/components/ServiceCaller/ServiceCaller.tsx
+++ b/src/components/ServiceCaller/ServiceCaller.tsx
@@ -1,31 +1,39 @@
-import React, { Fragment, useEffect } from "react";
-import PropTypes from "prop-types";
-import { useRos } from "../RosConnection";
-import { Ros, Service, ServiceRequest, ServiceResponse } from "roslib";
-
+import React, { Fragment, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useRos } from '../RosConnection';
+import { Ros, Service, ServiceRequest, ServiceResponse } from 'roslib';
 
 export const ServiceCaller = (props: ServiceCallerProps) => {
-    const {name, serviceType, trigger, request, callback, failedCallback} = props;
+    const { name, serviceType, trigger, request, callback, failedCallback } = props;
     const ros = useRos();
     useEffect(() => {
         if (trigger) {
             callService(ros, name, serviceType, request, callback, failedCallback);
         }
-    }, [trigger])
+    }, [trigger]);
 
-    return <Fragment/>
-}
+    return <Fragment />;
+};
 
+export type DefaultSrvReqType = object;
+export type DefaultSrvRespType = ServiceResponse;
 
-interface ServiceCallerProps {
+export interface ServiceCallerProps<
+    TReq = DefaultSrvReqType,
+    TResp = DefaultSrvRespType,
+> {
     name: string;
     serviceType: string;
     trigger?: boolean;
-    request?: object;
-    callback?: (resp: ServiceResponse) => void;
+    request?: TReq;
+    callback?: (resp: TResp) => void;
     failedCallback?: (error: any) => void;
 }
 
+export type ServiceCB<
+    TReq = DefaultSrvReqType,
+    TResp = DefaultSrvRespType,
+> = ServiceCallerProps<TReq, TResp>['callback'];
 
 ServiceCaller.propTypes = {
     name: PropTypes.string.isRequired,
@@ -34,11 +42,21 @@ ServiceCaller.propTypes = {
     request: PropTypes.object,
     callback: PropTypes.func,
     failedCallback: PropTypes.func,
-}
+};
 
+function respCb<TResp = DefaultSrvRespType>(resp: TResp) {}
 
-export function callService(ros: Ros, name: string, serviceType: string, request?: object, callback: ((resp: ServiceResponse) => void) = (resp) => {;}, failedCallback?: ((error: any) => void)) {
-    const service = new Service({ros, name, serviceType});
+export function callService<TReq = DefaultSrvReqType, TResp = DefaultSrvRespType>(
+    ros: Ros,
+    name: string,
+    serviceType: string,
+    request?: TReq,
+    callback: ServiceCB<unknown, TResp> = respCb<TResp>,
+    failedCallback?: (error: any) => void,
+) {
+    // ServiceRequest just runs Object.assign under the hood, no reason to template as TReq
+    // Just need to take in TReq and pass to ServiceRequest
+    const service = new Service<ServiceRequest, TResp>({ ros, name, serviceType });
     const serviceRequest = new ServiceRequest(request);
     service.callService(serviceRequest, callback, failedCallback);
 }

--- a/src/components/ServiceCaller/index.ts
+++ b/src/components/ServiceCaller/index.ts
@@ -1,1 +1,2 @@
-export { ServiceCaller, callService } from "./ServiceCaller";
+export { ServiceCaller, callService } from './ServiceCaller';
+export { useServiceCall, ServiceCallHookProps } from './useServiceCall';

--- a/src/components/ServiceCaller/useServiceCall.tsx
+++ b/src/components/ServiceCaller/useServiceCall.tsx
@@ -29,7 +29,7 @@ export function useServiceCall<TReq = DefaultSrvReqType, TResp = DefaultSrvRespT
                 failedCallback,
             );
         },
-        [name, serviceType, callback, failedCallback],
+        [ros, name, serviceType, callback, failedCallback],
     );
 
     const callSrvPromise = useCallback(
@@ -45,7 +45,7 @@ export function useServiceCall<TReq = DefaultSrvReqType, TResp = DefaultSrvRespT
                 );
             });
         },
-        [name, serviceType, callback, failedCallback],
+        [ros, name, serviceType],
     );
 
     return { callSrv, callSrvPromise };

--- a/src/components/ServiceCaller/useServiceCall.tsx
+++ b/src/components/ServiceCaller/useServiceCall.tsx
@@ -1,0 +1,52 @@
+import {
+    callService,
+    DefaultSrvReqType,
+    DefaultSrvRespType,
+    ServiceCallerProps,
+} from './ServiceCaller';
+import { useRos } from '../RosConnection';
+import { useCallback } from 'react';
+
+export type ServiceCallHookProps<
+    TReq = DefaultSrvReqType,
+    TResp = DefaultSrvRespType,
+> = Omit<ServiceCallerProps<TReq, TResp>, 'trigger' | 'request'>;
+
+export function useServiceCall<TReq = DefaultSrvReqType, TResp = DefaultSrvRespType>(
+    props: ServiceCallHookProps<TReq, TResp>,
+) {
+    const ros = useRos();
+    const { name, serviceType, callback, failedCallback } = props;
+
+    const callSrv = useCallback(
+        (request: TReq) => {
+            callService<TReq, TResp>(
+                ros,
+                name,
+                serviceType,
+                request,
+                callback,
+                failedCallback,
+            );
+        },
+        [name, serviceType, callback, failedCallback],
+    );
+
+    const callSrvPromise = useCallback(
+        (request: TReq) => {
+            return new Promise<TResp>((resolve, reject) => {
+                callService<TReq, TResp>(
+                    ros,
+                    name,
+                    serviceType,
+                    request,
+                    res => resolve(res),
+                    reject,
+                );
+            });
+        },
+        [name, serviceType, callback, failedCallback],
+    );
+
+    return { callSrv, callSrvPromise };
+}


### PR DESCRIPTION
This PR is like #2 in providing a hook-based option for service calls in addition to the default fragment component.

Takes in all the same arguments and returns 2 functions:
1. `callSrv(reqObj)`: Takes in the request and sends the service call, using the callbacks when complete
2. `callSrvPromise(reqObj)`: Takes the request and sends the call, returns a promise which can be used however you want. Callback and failedCallback props can be left blank when using this option.

Example: 
```ts
export const TestServiceComponent: React.FC<TestServiceComponentProps> = () => {
  const [sum, setSum] = useState<number | undefined>();
  const [firstNum, setFirstNum] = useState(0);
  const [secondNum, setSecondNum] = useState(0);

  const testServiceProps: ServiceCallHookProps<AddTwoInts.Request, AddTwoInts.Response> =
    {
      name: '/rosbridgetest/add_two_ints',
      serviceType: 'example_interfaces/AddTwoInts',
      callback: result => setSum(result.sum),
      failedCallback: e => console.error(e),
    };

  const { callSrv } = useServiceCall(testServiceProps);

  return (
    <Flexbox row alignItems={'center'} justifyContent={'center'} gap={'0.5rem'}>
      <Flexbox column gap={'0.125rem'}>
        <label>
          Number 1:
          <input
            type={'number'}
            value={firstNum}
            onChange={e => setFirstNum(e.target.valueAsNumber)}
          />
        </label>
        <label>
          Number 2:
          <input
            type={'number'}
            value={secondNum}
            onChange={e => setSecondNum(e.target.valueAsNumber)}
          />
        </label>
        <Btn onClick={() => callSrv({ a: firstNum, b: secondNum })}>Submit</Btn>
      </Flexbox>
      <div>Sum: {sum}</div>
    </Flexbox>
  );
};
```

![Screenshot 2023-05-02 at 4 33 21 PM](https://user-images.githubusercontent.com/84148896/235779680-09e69b90-89d7-430e-9534-1a6b884bda8b.png)
