### PR TITLE
Fixed bugs related to RosConnection connecting but not updating children

### DIFF
--- a/src/components/RosConnection/AuthenticationMessage.ts
+++ b/src/components/RosConnection/AuthenticationMessage.ts
@@ -1,0 +1,33 @@
+import { sha512 } from 'js-sha512';
+
+export class AuthenticationMessage {
+    secret: string;
+    client: string;
+    dest: string;
+    rand: string;
+    time: number;
+    timeEnd: number;
+    level: string;
+
+    constructor(url: string, user: string, password: string) {
+        this.dest = url;
+        this.client = user;
+        this.secret = password;
+        this.rand = 'randomstring';
+        this.time = new Date().getTime();
+        this.level = 'user';
+        this.timeEnd = this.time;
+    }
+
+    getMac() {
+        return sha512(
+            this.secret +
+                this.client +
+                this.dest +
+                this.rand +
+                this.time.toString() +
+                this.level +
+                this.timeEnd.toString(),
+        );
+    }
+}

--- a/src/components/RosConnection/RosInstanceManager.ts
+++ b/src/components/RosConnection/RosInstanceManager.ts
@@ -20,6 +20,7 @@ const RosInstances: RosInstanceHolder = {};
 export const getRosObject = (url: string, options: RosPropsWithoutUrl = {}): Ros => {
     let rosInstance = new Ros(options);
     rosInstance.uid = uuidv4();
+    rosInstance.connectorCallbacks = new Map();
     if (RosInstances[url] === undefined) {
         // cache miss, store
         RosInstances[url] = rosInstance;

--- a/src/components/RosConnection/index.ts
+++ b/src/components/RosConnection/index.ts
@@ -1,3 +1,4 @@
+export { AuthenticationMessage } from './AuthenticationMessage';
 export {
     closeConnection,
     connect,

--- a/src/components/common.ts
+++ b/src/components/common.ts
@@ -1,5 +1,7 @@
 import { Context, useContext } from 'react';
 
+export type VoidFunc = () => void;
+
 export function useCheckedContext(contextType: Context<any>): any {
     const context = useContext(contextType);
     if (context === undefined) {
@@ -15,10 +17,14 @@ export function useCheckedContext(contextType: Context<any>): any {
  */
 declare module 'roslib' {
     interface Ros {
+        // UUID to identify an instance
         uid?: string;
+        // Callbacks specifically added by RosConnection, to easily remove later
+        connectorCallbacks: Map<string, Set<VoidFunc>>;
     }
 
     interface Topic {
+        // Hash of settings for easy lookup
         settingsHash?: string;
     }
 }


### PR DESCRIPTION
This PR fixes an issue introduced in 0.4.0.  
When using the new Ros connection caching, the Ref used to keep track of the Ros instance would change but not actually update on first connect. This causes any children using that RosConnection to never subscribe to their topics.

This is fixed by removing the Ref and directly accessing the cache with `getRosObject`, since it's directly derived from the URL anyway.  
Another consequence of allowing multiple RosConnection components is that there's a possibility some of them will unmount and then remount later. This creates an issue because the callback functions registered by `setupConnectionCallbacks` are never removed when the component unmounts.  
This PR adds another module augmentation to the `Ros` object, to add a collection of functions that RosConnection manages, this way when it comes time to unmount and close the connection, we already have all the things we need to remove handy. This was the way I came up with, but I'm open to suggestions if you think there's a better way

This PR also moves AuthenticationMessage to its own file for neatness.

Fixes #6